### PR TITLE
[templaterelations] Bot definitions (not NPCs) must have Null missionLevels

### DIFF
--- a/Staging_Dev/FIX_robottemplaterelation_pinkarkhe.sql
+++ b/Staging_Dev/FIX_robottemplaterelation_pinkarkhe.sql
@@ -1,0 +1,11 @@
+USE [perpetuumsa]
+GO
+
+------Pink Arkhe showing up in mission fix--------
+
+PRINT N'BOT DEFINITIONS NEED TO HAVE NULL MISSION LEVELS!';
+UPDATE robottemplaterelation
+SET missionlevel=NULL, missionleveloverride=NULL, killep=NULL
+WHERE definition = (SELECT TOP 1 definition FROM entitydefaults WHERE definitionname='def_arkhe2_bot_pink');
+
+GO


### PR DESCRIPTION
Otherwise they show up in missions! oh no!