### PR TITLE
Omega remove dead teleport column (disable)

### DIFF
--- a/Staging_Dev/ZoneEntities_remove_stronghold_tele_column__2019_04_01.sql
+++ b/Staging_Dev/ZoneEntities_remove_stronghold_tele_column__2019_04_01.sql
@@ -1,0 +1,16 @@
+USE [perpetuumsa]
+GO
+
+-------------------------------------------
+--Remove (disable) Teleport on Omega
+--Date: 2019/04/01
+-------------------------------------------
+
+
+UPDATE dbo.zoneentities SET
+enabled=0
+WHERE 
+ename='tp_zone_16_1' AND
+zoneID = (SELECT TOP 1 id FROM dbo.zones WHERE name='zone_pvp_arena');
+
+GO


### PR DESCRIPTION
Teleport connection was removed, the column should be removed (disabled) to not confuse players.