### PR TITLE
Balance: missing armor plate tweaks 

### DIFF
--- a/Staging_Dev/Balance_armorplates_missedartifacttype__2019_07_13.sql
+++ b/Staging_Dev/Balance_armorplates_missedartifacttype__2019_07_13.sql
@@ -1,0 +1,37 @@
+USE [perpetuumsa]
+GO
+
+------------------------------------------------------
+--Armor plate balance bugs: missed artifact types
+--Massiveness was out of line from previous balancing to plates
+--Date: 2019/07/13
+------------------------------------------------------
+
+
+DECLARE @definitionID int;
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+
+PRINT N'def_artifact_a_small_armor_plate';
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_armor_plate' ORDER BY definition DESC);
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'massiveness' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.11 WHERE id =  @aggvalueID;
+
+PRINT N'def_artifact_a_medium_armor_plate';
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_armor_plate' ORDER BY definition DESC);
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'massiveness' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.13 WHERE id =  @aggvalueID;
+
+PRINT N'def_artifact_damaged_medium_armor_plate';
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_damaged_medium_armor_plate' ORDER BY definition DESC);
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'massiveness' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.12 WHERE id =  @aggvalueID;
+
+
+GO


### PR DESCRIPTION
From previous balancing agenda, artifact type plates were missed.
They are now consistent with t3- and t0 metas given the demob immunity changes from earlier