### PR TITLE
Stronghold entrance item

### DIFF
--- a/Staging_Dev/Entitydefaults_insert_mob_tele_strnghld__2020_04_03.sql
+++ b/Staging_Dev/Entitydefaults_insert_mob_tele_strnghld__2020_04_03.sql
@@ -33,13 +33,13 @@ END
 IF NOT EXISTS (SELECT definition FROM entitydefaults WHERE definitionname=@fieldDevName)
 BEGIN
 INSERT INTO [dbo].[entitydefaults] ([definitionname],[quantity],[attributeflags],[categoryflags],[options],[note],[enabled],[volume],[mass],[hidden],[health],[descriptiontoken],[purchasable],[tiertype],[tierlevel]) VALUES
-(@fieldDevName,1,12583936,17171064,'','Stronghold teleport field obj',1,4,8000,0,100,'def_mobile_teleport_stronghold_basic_desc',0,0,0);
+(@fieldDevName,1,12583936,33948280,'','Stronghold teleport field obj',1,4,8000,0,100,'def_mobile_teleport_stronghold_basic_desc',0,0,0);
 END
 ELSE
 BEGIN
 	UPDATE entitydefaults SET
 		attributeflags = 12583936,
-		categoryflags = 17171064,
+		categoryflags = 33948280,
 		note = 'Stronghold teleport field ob',
 		volume = 4,
 		mass = 8000

--- a/Staging_Dev/Entitydefaults_insert_mob_tele_strnghld__2020_04_03.sql
+++ b/Staging_Dev/Entitydefaults_insert_mob_tele_strnghld__2020_04_03.sql
@@ -1,0 +1,65 @@
+USE [perpetuumsa]
+GO
+
+------------------------------------------------------------------
+--Stronghold teleporter item definitions
+--Adds or updates entitydefaults
+--Date modified: 2020/04/03
+------------------------------------------------------------------
+
+
+DECLARE @capsuleName VARCHAR(128);
+DECLARE @fieldDevName VARCHAR(128);
+
+SET @capsuleName = 'def_mobile_teleport_stronghold_capsule';
+SET @fieldDevName = 'def_mobile_teleport_stronghold_basic';
+
+IF NOT EXISTS (SELECT definition FROM entitydefaults WHERE definitionname=@capsuleName)
+BEGIN
+	INSERT INTO [dbo].[entitydefaults] ([definitionname],[quantity],[attributeflags],[categoryflags],[options],[note],[enabled],[volume],[mass],[hidden],[health],[descriptiontoken],[purchasable],[tiertype],[tierlevel]) VALUES
+	(@capsuleName,1,25167872,131480,'','Stronghold teleport capsule',1,4,8000,0,100,'def_mobile_teleport_stronghold_capsule_desc',1,0,0);
+END
+ELSE
+BEGIN
+	UPDATE entitydefaults SET
+		attributeflags = 25167872,
+		categoryflags = 131480,
+		note = 'Stronghold teleport capsule',
+		volume = 4,
+		mass = 8000
+	WHERE definitionname=@capsuleName;
+END
+
+IF NOT EXISTS (SELECT definition FROM entitydefaults WHERE definitionname=@fieldDevName)
+BEGIN
+INSERT INTO [dbo].[entitydefaults] ([definitionname],[quantity],[attributeflags],[categoryflags],[options],[note],[enabled],[volume],[mass],[hidden],[health],[descriptiontoken],[purchasable],[tiertype],[tierlevel]) VALUES
+(@fieldDevName,1,12583936,17171064,'','Stronghold teleport field obj',1,4,8000,0,100,'def_mobile_teleport_stronghold_basic_desc',0,0,0);
+END
+ELSE
+BEGIN
+	UPDATE entitydefaults SET
+		attributeflags = 12583936,
+		categoryflags = 17171064,
+		note = 'Stronghold teleport field ob',
+		volume = 4,
+		mass = 8000
+	WHERE definitionname=@fieldDevName;
+END
+
+
+IF NOT EXISTS (SELECT definition FROM definitionconfig WHERE definition=(SELECT TOP 1 definition FROM entitydefaults WHERE definitionname = @capsuleName))
+BEGIN
+	INSERT INTO definitionconfig (definition, targetdefinition, action_delay, note) VALUES
+	((SELECT TOP 1 definition FROM entitydefaults WHERE definitionname = @capsuleName), 
+	(SELECT TOP 1 definition FROM entitydefaults WHERE definitionname = @fieldDevName), 
+	120000, 
+	'Stronghold mobile teleport mapping');
+END
+ELSE
+BEGIN
+	UPDATE definitionconfig SET
+		action_delay=120000
+	WHERE definition=(SELECT TOP 1 definition FROM entitydefaults WHERE definitionname = @capsuleName);
+END
+
+GO

--- a/Staging_Dev/Zoneentity_insert_strnghld_tele_col__2020_04_03.sql
+++ b/Staging_Dev/Zoneentity_insert_strnghld_tele_col__2020_04_03.sql
@@ -1,0 +1,62 @@
+USE [perpetuumsa]
+GO
+
+------------------------------------------------------------------
+--Add teleport column to Omega (stronghold zone)
+--Adds or updates zoneentities
+--Date modified: 2020/04/03
+------------------------------------------------------------------
+
+DECLARE @targetZoneID int;
+SET @targetZoneID = (SELECT TOP 1 id FROM zones WHERE name='zone_pvp_arena' AND zonetype=4);
+
+DECLARE @ename VARCHAR(128);
+SET @ename = 'tp_zone_strnghld_01';
+
+DECLARE @parentEntity bigint;
+SET @parentEntity = (SELECT TOP 1 eid from entitystorage where storage_name='teleport_column');
+
+DECLARE @eid bigint;
+SET @eid = 50000;
+
+IF NOT EXISTS (SELECT eid FROM entities WHERE ename=@ename)
+BEGIN
+	INSERT INTO entities (eid, definition, owner, parent, health, ename, quantity, repackaged, dynprop) VALUES
+	(@eid, 1394, NULL, @parentEntity, 100, @ename, 1, 0, '#enabled=i1');
+END
+ELSE
+BEGIN
+	UPDATE entities SET
+		eid=@eid,
+		definition=1394,
+		parent=@parentEntity,
+		health=100,
+		quantity=1,
+		repackaged=0,
+		dynprop='#enabled=i1'
+	WHERE ename=@ename;
+END
+
+
+IF NOT EXISTS (SELECT eid FROM zoneentities WHERE ename=@ename)
+BEGIN
+	INSERT INTO zoneentities (zoneID, eid, definition, owner, ename, x, y, z, orientation, enabled, note, runtime, synckey) VALUES 
+	(@targetZoneID, @eid, NULL, NULL, @ename, 1108, 1048, 50, 128, 1, 'stronghold teleport 1', 0, 'tp_strnghld_01');
+END
+ELSE
+BEGIN
+	UPDATE zoneentities SET
+		zoneID = @targetZoneID,
+		eid=@eid,
+		x = 1108,
+		y = 1048,
+		z = 50,
+		orientation = 128,
+		enabled = 1,
+		note = 'stronghold teleport 1',
+		runtime = 0,
+		synckey = 'tp_strnghld_01'
+	WHERE ename=@ename;
+END
+
+GO


### PR DESCRIPTION
 - Adds mobile teleport deployer and deployed item definitions, and their relation via def config
 - Adds teleport column (the right way) to stronghold zone

Closes: https://github.com/OpenPerpetuum/OPDB/pull/200
For: https://github.com/OpenPerpetuum/PerpetuumServer/pull/139