### PR TITLE
In-zone teleport type fix

### DIFF
--- a/Staging_Dev/teleportdescriptions_update__2020_08_02.sql
+++ b/Staging_Dev/teleportdescriptions_update__2020_08_02.sql
@@ -1,0 +1,21 @@
+USE [perpetuumsa]
+GO
+
+--------------------------------------------------------
+-- Teleports that perform in-zone jumps should use in-zonejump type
+--
+-- Date 2020/08/02
+--------------------------------------------------------
+
+
+--PRINT N'Teleports that should be type=1 for in-zone';
+--SELECT * FROM teleportdescriptions 
+--WHERE targetzone=sourcezone AND
+--	type!=1
+
+PRINT N'Update to type=1 WHERE targetzone=sourcezone';
+UPDATE teleportdescriptions SET
+	type=1
+WHERE targetzone=sourcezone AND type!=1;
+
+GO


### PR DESCRIPTION
This `type` field was used to pick a teleport strategy.
It seems like the logic of the source/target zones being equal would be sufficient, but perhaps this was to allow custom teleport behaviors...
... that gives me an idea!

Later, first make these behave right.