### PR TITLE
Reduce goblin range 

### DIFF
--- a/Staging_Dev/def_npc_goblin_lancer__2020_08_16_16_14_34.sql
+++ b/Staging_Dev/def_npc_goblin_lancer__2020_08_16_16_14_34.sql
@@ -1,0 +1,29 @@
+USE [perpetuumsa]
+GO
+
+-----------------------------------------------
+-- Reduce range of Goblin Lancer to force closer to players
+--
+-- Date: 2020/08/16
+-----------------------------------------------
+
+
+DECLARE @definitionID int;
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_goblin_lancer' ORDER BY definition DESC);
+
+UPDATE entitydefaults Set definitionname='def_npc_goblin_lancer', quantity=1, attributeflags=1024, categoryflags=1423, options='', 
+                note='', enabled=1, volume=0, mass=0, hidden=0, health=100, descriptiontoken='def_npc_goblin_lancer_desc', purchasable=0, tiertype=0, 
+                tierlevel=0 where definition=@definitionID;
+
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'falloff_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'optimal_range_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.9 WHERE id =  @aggvalueID;
+
+GO


### PR DESCRIPTION
Players are getting ecm'ed at great distances, often confusing new players.
Should pull them closer for players with extra weapon to shoot them with little effort.