### PR TITLE
Retrofixes

### DIFF
--- a/Patches/Live_10/live_patch_10.sql
+++ b/Patches/Live_10/live_patch_10.sql
@@ -2379,121 +2379,6 @@ INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probabili
 
 GO
 
------------------------------------------------------------
---OPP_Anniversary_gift_robot__2019_03_30.sql
------------------------------------------------------------
-
-USE [perpetuumsa]
-GO
-
------------------------------------------------
---OPP 1 Year of LIVE server anniversary gifts!
---New robot definition
---New Package and gifts
---Procedure call to distribute gifts
---Date: 2019/03/20
------------------------------------------------
-
-
-PRINT N'1. Create entity)';
---WARNING: options string contains references to entitydefaults in hex (Head/leg/chassis are fixed definitions from arkhe mk2)
---ENTITYDEFAULT SAVE NEW
-INSERT INTO entitydefaults (definitionname, quantity, attributeflags, categoryflags, options, note, enabled,  volume, mass, hidden, health, descriptiontoken, purchasable, tiertype, tierlevel) 
-VALUES ( 'def_AnniversArkhe_bot', 1, 0, 257, '#head=iae8#chassis=iae9#leg=iaea#container=i147#tier=$tierlevel_mk2', 'New Arkhe for 1yr aniversary!', 1, 12, 0, 'False', 100, 'def_arkhe2_bot_desc', 1, 1, 2); 
-GO
-
-PRINT N'2. Create template (from tool)';
---WARNING: description string contains references to entitydefaults in hex
---TEMPLATE INSERT
-
-DECLARE @definitionHex varchar;
---This is how to do lookups, convert to hex, and concat into a genxy compatible string!
-SET @definitionHex = (SELECT dbo.ToHex(definition) FROM entitydefaults WHERE definitionname='def_AnniversArkhe_bot');
-
-INSERT INTO robottemplates ([name], [description], [note]) 
-VALUES ('def_anniversarkhe_bot_template', '#robot=i'+@definitionHex+'#head=iae8#chassis=iae9#leg=iaea#container=i147#headModules=[|m0=[|definition=i0|slot=i1]]#chassisModules=[|m0=[|definition=i0|slot=i1]|m1=[|definition=i0|slot=i2]]#legModules=[|m0=[|definition=i0|slot=i1]|m1=[|definition=i0|slot=i2]]', 'OPP Live 1 year anniversary Reward');
-GO
-
-PRINT N'3. Create templaterelation';
-INSERT INTO [dbo].[robottemplaterelation]
-           ([definition],[templateid],[itemscoresum],[raceid],[missionlevel],[missionleveloverride],[killep],[note])
-     VALUES
-           ((SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot')
-           ,(SELECT TOP 1 id from robottemplates where name='def_anniversarkhe_bot_template'),0,1,NULL,NULL,NULL,'AnniversArkhe Template Relation year1');
-GO
-
-PRINT N'4. Insert config w/ desired tint';
-INSERT INTO [dbo].[definitionconfig]
-           ([definition],[tint],[note])
-     VALUES
-           ((SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot')
-           ,'#8bff00'
-           ,'Color for AnniversArkhe bot');
-GO
-
-PRINT N'5. Give bot skills -- ARKHE MK2 HAS NO ENABLER SKILLS RESULT WILL BE 0 rows affected';
---Use existing bot (that was copied from entitydefault) for extensions
-INSERT INTO [dbo].[enablerextensions]
-           ([definition],[extensionid],[extensionlevel])
-     (SELECT (SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot'), extensionid, extensionlevel from enablerextensions where definition=(Select top 1 definition from entitydefaults where definitionname='def_arkhe2_bot'));
-GO
-
-
-
-PRINT N'Create Packages for pre-alpha participant levels';
-INSERT INTO [dbo].[packages]
-           ([name],[note])
-     VALUES
-           ('opp-anniversary01','1 year of OPP Live!');
-GO
-
-PRINT N'Insert items into Packages for pre-alpha participant levels';
-DECLARE @packid int;
-SET @packid = (SELECT TOP 1 id from packages where name='opp-anniversary01');
-
-DECLARE @aid int;
-SET @aid = (SELECT TOP 1 definition from entitydefaults where definitionname='def_anniversary_package');
-
-DECLARE @specialBot int;
-SET @specialBot = (SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot');
-
-DECLARE @epBoostT1 int;
-SET @epBoostT1 = (SELECT TOP 1 definition from entitydefaults where definitionname='def_boost_ep_t1');
-
-PRINT N'Items for opp-anniversary01!!!';
-INSERT INTO [dbo].[packageitems]
-           ([packageid],[definition],[quantity])
-     VALUES
-           (@packid, @aid, 2), 
-		   (@packid, @specialBot, 1),
-		   (@packid, @epBoostT1, 1);
-
-GO
-
-
-
-DECLARE @packid int;
-SET @packid = (SELECT TOP 1 id from packages where name='opp-anniversary01');
---TODO use variant of below for future gifting
---This gift gives to all current accounts at patch-time
-PRINT N'Give everyone a gift! WARNING CURSOR AHEAD!';
-DECLARE @id int
-DECLARE @pass varchar(100)
-
-DECLARE curse CURSOR FOR SELECT accountID FROM accounts
-OPEN curse
-
-FETCH NEXT FROM curse INTO @id
-
-WHILE @@FETCH_STATUS = 0 BEGIN
-    EXEC dbo.accountPackageProcessOne @id, @packid
-    FETCH NEXT FROM curse INTO @id
-END
-
-CLOSE curse    
-DEALLOCATE curse
-
-GO
 
 --------------------------------------------------------
 --Relics_init_all__2019_02_27.sql
@@ -3362,6 +3247,124 @@ SELECT * from relicloot;
 --wow cool
 
 PRINT N'DONE! Init-ing relic tables';
+
+GO
+
+
+
+-----------------------------------------------------------
+--OPP_Anniversary_gift_robot__2019_03_30.sql
+-----------------------------------------------------------
+
+USE [perpetuumsa]
+GO
+
+-----------------------------------------------
+--OPP 1 Year of LIVE server anniversary gifts!
+--New robot definition
+--New Package and gifts
+--Procedure call to distribute gifts
+--Date: 2019/03/20
+-----------------------------------------------
+
+
+PRINT N'1. Create entity)';
+--WARNING: options string contains references to entitydefaults in hex (Head/leg/chassis are fixed definitions from arkhe mk2)
+--ENTITYDEFAULT SAVE NEW
+INSERT INTO entitydefaults (definitionname, quantity, attributeflags, categoryflags, options, note, enabled,  volume, mass, hidden, health, descriptiontoken, purchasable, tiertype, tierlevel) 
+VALUES ( 'def_AnniversArkhe_bot', 1, 0, 257, '#head=iae8#chassis=iae9#leg=iaea#container=i147#tier=$tierlevel_mk2', 'New Arkhe for 1yr aniversary!', 1, 12, 0, 'False', 100, 'def_arkhe2_bot_desc', 1, 1, 2); 
+GO
+
+PRINT N'2. Create template (from tool)';
+--WARNING: description string contains references to entitydefaults in hex
+--TEMPLATE INSERT
+
+DECLARE @definitionHex varchar;
+--This is how to do lookups, convert to hex, and concat into a genxy compatible string!
+SET @definitionHex = (SELECT dbo.ToHex(definition) FROM entitydefaults WHERE definitionname='def_AnniversArkhe_bot');
+
+INSERT INTO robottemplates ([name], [description], [note]) 
+VALUES ('def_anniversarkhe_bot_template', '#robot=i'+@definitionHex+'#head=iae8#chassis=iae9#leg=iaea#container=i147#headModules=[|m0=[|definition=i0|slot=i1]]#chassisModules=[|m0=[|definition=i0|slot=i1]|m1=[|definition=i0|slot=i2]]#legModules=[|m0=[|definition=i0|slot=i1]|m1=[|definition=i0|slot=i2]]', 'OPP Live 1 year anniversary Reward');
+GO
+
+PRINT N'3. Create templaterelation';
+INSERT INTO [dbo].[robottemplaterelation]
+           ([definition],[templateid],[itemscoresum],[raceid],[missionlevel],[missionleveloverride],[killep],[note])
+     VALUES
+           ((SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot')
+           ,(SELECT TOP 1 id from robottemplates where name='def_anniversarkhe_bot_template'),0,1,NULL,NULL,NULL,'AnniversArkhe Template Relation year1');
+GO
+
+PRINT N'4. Insert config w/ desired tint';
+INSERT INTO [dbo].[definitionconfig]
+           ([definition],[tint],[note])
+     VALUES
+           ((SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot')
+           ,'#8bff00'
+           ,'Color for AnniversArkhe bot');
+GO
+
+PRINT N'5. Give bot skills -- ARKHE MK2 HAS NO ENABLER SKILLS RESULT WILL BE 0 rows affected';
+--Use existing bot (that was copied from entitydefault) for extensions
+INSERT INTO [dbo].[enablerextensions]
+           ([definition],[extensionid],[extensionlevel])
+     (SELECT (SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot'), extensionid, extensionlevel from enablerextensions where definition=(Select top 1 definition from entitydefaults where definitionname='def_arkhe2_bot'));
+GO
+
+
+
+PRINT N'Create Packages for pre-alpha participant levels';
+INSERT INTO [dbo].[packages]
+           ([name],[note])
+     VALUES
+           ('opp-anniversary01','1 year of OPP Live!');
+GO
+
+PRINT N'Insert items into Packages for pre-alpha participant levels';
+DECLARE @packid int;
+SET @packid = (SELECT TOP 1 id from packages where name='opp-anniversary01');
+
+DECLARE @aid int;
+SET @aid = (SELECT TOP 1 definition from entitydefaults where definitionname='def_anniversary_package');
+
+DECLARE @specialBot int;
+SET @specialBot = (SELECT TOP 1 definition from entitydefaults where definitionname='def_AnniversArkhe_bot');
+
+DECLARE @epBoostT1 int;
+SET @epBoostT1 = (SELECT TOP 1 definition from entitydefaults where definitionname='def_boost_ep_t1');
+
+PRINT N'Items for opp-anniversary01!!!';
+INSERT INTO [dbo].[packageitems]
+           ([packageid],[definition],[quantity])
+     VALUES
+           (@packid, @aid, 2), 
+		   (@packid, @specialBot, 1),
+		   (@packid, @epBoostT1, 1);
+
+GO
+
+
+
+DECLARE @packid int;
+SET @packid = (SELECT TOP 1 id from packages where name='opp-anniversary01');
+--TODO use variant of below for future gifting
+--This gift gives to all current accounts at patch-time
+PRINT N'Give everyone a gift! WARNING CURSOR AHEAD!';
+DECLARE @id int
+DECLARE @pass varchar(100)
+
+DECLARE curse CURSOR FOR SELECT accountID FROM accounts
+OPEN curse
+
+FETCH NEXT FROM curse INTO @id
+
+WHILE @@FETCH_STATUS = 0 BEGIN
+    EXEC dbo.accountPackageProcessOne @id, @packid
+    FETCH NEXT FROM curse INTO @id
+END
+
+CLOSE curse    
+DEALLOCATE curse
 
 GO
 

--- a/Patches/Live_11/live_patch_11.sql
+++ b/Patches/Live_11/live_patch_11.sql
@@ -298,6 +298,1089 @@ GO
 -------------------------------------------------------------------------------------------------------------------
 
 
+PRINT N'PitBoss_and_EPboostitem_t0loot__2019_05_23';
+----------------------------------------------------------------------------------------------------------------
+----PART 1 ADD NEW EP ITEM
+
+
+USE [perpetuumsa]
+GO
+
+-------------------------------------------------
+--INSERTS ENTITYDEFAULT****
+--T0 EP boost item for Pitboss loot
+--REQUIRED FOR PITBOSS LOOT PATCH
+--Date: 2019/05/19
+-------------------------------------------------
+
+
+
+PRINT N'INSERT ENTITYDEFAULT def_boost_ep_t0';
+--Insert a T0 variant EP boost item for Pitboss loot only
+INSERT INTO [dbo].[entitydefaults]
+           ([definitionname]
+           ,[quantity]
+           ,[attributeflags]
+           ,[categoryflags]
+           ,[options]
+           ,[note]
+           ,[enabled]
+           ,[volume]
+           ,[mass]
+           ,[hidden]
+           ,[health]
+           ,[descriptiontoken]
+           ,[purchasable]
+           ,[tiertype]
+           ,[tierlevel])
+     VALUES
+           ('def_boost_ep_t0'
+           ,1
+           ,2052
+           ,1179
+           ,'#addBoost=n1 #timePeriodHours=i1 #tier=$tierlevel_t0'
+           ,'Adds 1 to the current EP multiplier for 1 hours'
+           ,1
+           ,1E-06
+           ,1E-06
+           ,0
+           ,100
+           ,'def_redeemable_ep_standard_desc'
+           ,1
+           ,1
+           ,0);
+GO
+
+--Insert "despawn time" as the intended duration of the item as milliseconds
+INSERT INTO dbo.aggregatevalues
+(
+	[definition],
+	[field],
+	[value]
+)
+VALUES
+(
+	(SELECT TOP 1 definition FROM entitydefaults WHERE definitionname='def_boost_ep_t0'),
+	(SELECT TOP 1 id FROM dbo.aggregatefields WHERE name='despawn_time'),
+	3600000
+);
+
+GO
+
+
+---PART 2 ADD PITBOSS
+
+USE [perpetuumsa]
+GO
+
+PRINT N'PITBOSS PATCH';
+--------------------------------------------------------------
+--PITBOSS PATCH
+--Compilation of previous dev-patches in order of execution
+--NPC_Pitboss_0_0__init__2018_10_15
+--NPC_Pitboss_0_1__npctweak__2018_10_27
+--NPC_Pitboss_0_2__loot_killep_npcmods_respawnrate__2019_01_13
+--NPC_Pitboss_0_3__loot_npc_fields__2019_01_27
+--NPC_Pitboss_0_4__fitting_modifiers_loot_updates__2019_03_30
+--
+--REQUIRES: 00_INSERT_Entitydefault_Epboostitem_t0__2019_05_19
+------------------------------------------------------------
+
+
+
+PRINT N'EXECUTING: NPC_Pitboss_0_0__init__2018_10_15';
+
+USE [perpetuumsa]
+GO
+
+--DEFINES NEW NPC
+--ENTITYDEFAULT
+--ROBOTTEMPLATE
+--ROBOTTEMPLATERELATION
+--AGGREGATEVALUES
+--NPCPRESENCE
+--NPCFLOCK
+
+--PITBOSS ON HERSHFIELD FOR DEV-TESTING PURPOSES ONLY
+
+
+DECLARE @templateID int;
+DECLARE @definitionID int;
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+DECLARE @flockID int;
+DECLARE @presenceID int;
+
+PRINT N'INSERT NEW NPC DEFINITION';
+INSERT INTO entitydefaults ( definitionname ,  quantity ,  attributeflags ,  categoryflags ,  options ,  note ,  enabled ,  volume ,  mass ,  hidden , 
+                health ,  descriptiontoken ,  purchasable ,  tiertype ,  tierlevel ) 
+                VALUES ( 'def_npc_Hersh_PitBoss', 1, 1024, 911, '', '', 1, 0, 0, 0, 100, 'def_npc_seth_heavydps_rank1_desc', 0, 0, 0); 
+
+PRINT N'INSERT NEW NPC ROBOTTEMPLATE';
+INSERT INTO robottemplates ([name], [description], [note]) VALUES ('Hersh_PitBoss', '#robot=i1594#head=i1595#chassis=i1596#leg=i1597#container=i14c#headModules=[|m0=[|definition=i2b|slot=i1]|m1=[|definition=i32|slot=i2]|m2=[|definition=i33|slot=i3]|m3=[|definition=i34|slot=i4]]#chassisModules=[|m0=[|definition=i3d|slot=i1|ammoDefinition=i986|ammoQuantity=i32]|m1=[|definition=i3d|slot=i2|ammoDefinition=i986|ammoQuantity=i32]|m2=[|definition=i3d|slot=i3|ammoDefinition=i986|ammoQuantity=i32]|m3=[|definition=i3d|slot=i4|ammoDefinition=i988|ammoQuantity=i32]|m4=[|definition=i3d|slot=i5|ammoDefinition=i988|ammoQuantity=i32]|m5=[|definition=i3d|slot=i6|ammoDefinition=i988|ammoQuantity=i32]]#legModules=[|m0=[|definition=i10|slot=i1]|m1=[|definition=i18|slot=i2]|m2=[|definition=i1a|slot=i3]|m3=[|definition=i19|slot=i4]|m4=[|definition=i1b|slot=i5]|m5=[|definition=i13|slot=i6]]', 'Pit Boss for Hershfield')
+
+
+PRINT N'INSERT NEW ROBOTTEMPLATE RELATION';
+SET @templateID = (SELECT TOP 1 id from robottemplates WHERE [name] = 'Hersh_PitBoss' ORDER BY id DESC)
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+--MISSION LEVEL AND MISSION LEVEL OVERRIDE NEED TO BE NULL!
+INSERT INTO [dbo].[robottemplaterelation] ([definition],[templateid],[itemscoresum],[raceid],[missionlevel],[missionleveloverride],[killep],[note])
+                VALUES (@definitionID,@templateID,0,0,NULL,NULL,40,'Hersh_Pit_Boss');
+
+PRINT N'INSERT AGGVALUES - NPC modifiers';
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 3.0);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.0);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.5);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'cpu_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.5);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.0);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'falloff_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.0);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_range_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.5);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.25);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'missile_cycle_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.0);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'optimal_range_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.0);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'powergrid_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'turret_cycle_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 0.75);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'received_repaired_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 10);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_amount_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 5.0);
+
+PRINT N'INSERT NPCPRESENCE';
+INSERT INTO [dbo].[npcpresence] ([name],[topx],[topy],[bottomx],[bottomy],[note],[spawnid],[enabled],[roaming],[roamingrespawnseconds]
+                ,[presencetype],[maxrandomflock],[randomcenterx],[randomcentery],[randomradius],[dynamiclifetime],[isbodypull],[isrespawnallowed],[safebodypull])
+                VALUES ('Presence_NPC_Hersh_PitBoss',7,7,2038,2038,'Hersh_BlueBoss',13,1,1,60,5,0,0,0,0,0,0,1,1);
+
+PRINT N'INSERT NPCFLOCK';
+SET @presenceID = (SELECT TOP 1 id from npcpresence WHERE [name] = 'Presence_NPC_Hersh_PitBoss' ORDER BY id DESC)
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+SET @flockID = (SELECT TOP 1 id from npcflock WHERE [name] = 'Hersh_Pit_Boss' ORDER BY id DESC);
+INSERT INTO[dbo].[npcflock]([name],[presenceid],[flockmembercount],[definition],[spawnoriginX],[spawnoriginY],[spawnrangeMin],[spawnrangeMax],[respawnseconds]
+                ,[totalspawncount],[homerange],[note],[respawnmultiplierlow],[enabled],[iscallforhelp],[behaviorType]) VALUES
+                ('Hersh_Pit_Boss', @presenceID, 1, @definitionID, 933, 1231, 0, 5, 60, 0, 100, 'Hersh_Pit_Boss', 1, 1, 1, 1); 
+
+GO
+
+PRINT N'COMPLETE: NPC_Pitboss_0_0__init__2018_10_15';
+
+PRINT N'EXECUTING: NPC_Pitboss_0_1__npctweak__2018_10_27';
+
+USE [perpetuumsa]
+GO
+
+--PITBOSS experiment balance part 2
+--Insert slowdown and masking drop
+--update other npc properties
+
+DECLARE @definitionID int;
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+UPDATE entitydefaults Set definitionname='def_npc_Hersh_PitBoss', quantity=1, attributeflags=1024, categoryflags=911, options='', 
+                note='', enabled=1, volume=0, mass=0, hidden='False', health=100, descriptiontoken='def_npc_seth_heavydps_rank1_desc', purchasable=0, tiertype=0, 
+                tierlevel=0 where definition=@definitionID;
+
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+
+--Set Speed of Pitboss to 50% of its max
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'speed_max_modifier' ORDER BY [name] DESC);
+
+INSERT INTO [dbo].[aggregatevalues]
+           ([definition],[field],[value])
+     VALUES
+           (@definitionID, @aggfieldID, 0.5);
+
+
+--Set modification of masking to -70 (result effect will be masking =10)
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'stealth_strength_modifier' ORDER BY [name] DESC);
+
+INSERT INTO [dbo].[aggregatevalues]
+           ([definition],[field],[value])
+     VALUES
+           (@definitionID, @aggfieldID, -70);
+
+
+
+--Redundant updates to above inserts -- For use as template to future tweaks
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'stealth_strength_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=-50 WHERE id =  @aggvalueID;
+
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'speed_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.5 WHERE id =  @aggvalueID;
+
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=3.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_amount_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=10.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'cpu_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=2.6 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.1 WHERE id =  @aggvalueID;
+
+
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'falloff_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.6 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_range_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.6 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.6 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'missile_cycle_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.85 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'optimal_range_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'powergrid_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=2.1 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'turret_cycle_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.85 WHERE id =  @aggvalueID;
+
+--Redundant updates to above inserts --
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'stealth_strength_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=-50 WHERE id =  @aggvalueID;
+
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'speed_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.5 WHERE id =  @aggvalueID;
+
+GO
+
+PRINT N'COMPLETE NPC_Pitboss_0_1__npctweak__2018_10_27';
+
+
+PRINT N'EXECUTING: NPC_Pitboss_0_2__loot_killep_npcmods_respawnrate__2019_01_13';
+
+
+USE [perpetuumsa]
+GO
+
+
+--SETS RESPAWN RATE TO 5 DAYS
+--UPDATES TEMPLATE/FITTINGS
+--KILLEP SET TO 1000
+--FASTER ARMOR REPAIR
+--FULL LOOT TABLE
+--Add Color!
+
+--PITBOSS ON HERSHFIELD FOR DEV-TESTING PURPOSES ONLY
+
+DECLARE @presenceID int
+DECLARE @flockID int;
+DECLARE @definitionID int;
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+
+--Presence Update - set respawn timer to 5 days!
+SET @presenceID = (SELECT TOP 1 id from npcpresence WHERE [name] = 'Presence_NPC_Hersh_PitBoss' ORDER BY id DESC)
+UPDATE [dbo].[npcpresence] SET [name] = 'Presence_NPC_Hersh_PitBoss',
+[topx] = 7,[topy] = 7,[bottomx] = 2038,[bottomy] = 2038,[note] = 'Hersh_Boss',[spawnid] = 13,[enabled] = 1,[roaming] = 1,
+[roamingrespawnseconds] = 432000, [presencetype] = 5, [maxrandomflock] = '', [randomcenterx] = '', [randomcentery] = '', 
+[randomradius] = '',[dynamiclifetime] = '' ,[isbodypull] = 0,[isrespawnallowed] = 1,[safebodypull] = 1
+WHERE id=@presenceID;
+
+--Set Flock respawn too (to be consistent)
+SET @flockID = (SELECT TOP 1 id from npcflock WHERE [name] = 'Hersh_Pit_Boss' ORDER BY id DESC);
+UPDATE [dbo].[npcflock] SET 
+[name] = 'Hersh_Pit_Boss' ,[presenceid] = @presenceID, [flockmembercount] = 1, 
+[definition] = @definitionID, [spawnoriginX] = 933, [spawnoriginY] = 1231 ,
+[spawnrangeMin] = 0, [spawnrangeMax] = 5,[respawnseconds] = 432000, 
+[totalspawncount] = 0, [homerange] = 100 ,[note] = 'Hersh_Pit_Boss',
+[respawnmultiplierlow] = 1, [enabled] = 1, [iscallforhelp] = 1, [behaviorType] = 1 
+WHERE id=@flockID;
+
+
+
+DECLARE @templateID int;
+SET @templateID = (SELECT TOP 1 id from robottemplates WHERE [name] = 'Hersh_PitBoss' ORDER BY id DESC);
+
+--Update fittings
+UPDATE robottemplates SET 
+name='Hersh_PitBoss', 
+description='#robot=i1594#head=i1595#chassis=i1596#leg=i1597#container=i14c#headModules=[|m0=[|definition=i2b|slot=i1]|m1=[|definition=i32|slot=i2]|m2=[|definition=i33|slot=i3]|m3=[|definition=i34|slot=i4]]#chassisModules=[|m0=[|definition=i3d|slot=i1|ammoDefinition=i986|ammoQuantity=i32]|m1=[|definition=i3d|slot=i2|ammoDefinition=i986|ammoQuantity=i32]|m2=[|definition=i3d|slot=i3|ammoDefinition=i986|ammoQuantity=i32]|m3=[|definition=i3d|slot=i4|ammoDefinition=i988|ammoQuantity=i32]|m4=[|definition=i3d|slot=i5|ammoDefinition=i988|ammoQuantity=i32]|m5=[|definition=i3d|slot=i6|ammoDefinition=i988|ammoQuantity=i32]]#legModules=[|m0=[|definition=i10|slot=i1]|m1=[|definition=i18|slot=i2]|m2=[|definition=i1a|slot=i3]|m3=[|definition=i1b|slot=i4]|m4=[|definition=i13|slot=i5]|m5=[|definition=i13|slot=i6]]',
+note='Pit Boss for Hershfield' 
+WHERE id=@templateID;
+
+--Update KillEP = 1000!
+UPDATE [dbo].[robottemplaterelation] SET 
+[templateid] = @templateID,[itemscoresum] = 0,[raceid] = 0,
+[missionlevel] = NULL,[missionleveloverride] = NULL,[killep] = 1000,
+[note] = 'Hersh_Pit_Boss' 
+WHERE [definition] = @definitionID;
+
+
+--Add faster armor repair cycles, resistance, accum
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_cycle_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.75);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_chemical' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_explosive' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_kinetic' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_thermal' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=3.5 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_amount_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=12.5 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.15 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.5 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.5 WHERE id =  @aggvalueID;
+
+
+---Add Color
+
+INSERT INTO [dbo].[definitionconfig]
+           ([definition],[targetdefinition],[summonerscount],[npcpresenceid],[item_work_range],[explosion_radius],[cycle_time],[damage_chemical]
+           ,[damage_explosive],[damage_kinetic],[damage_thermal],[lifetime],[activationtime],[waves],[missionrelated],[constructionradius],[action_delay]
+           ,[deploy_radius],[transmitradius],[constructionlevelmax],[blockingradius],[chargeamount],[inconnections],[outconnections],[coretransferred],[transferefficiency]
+           ,[productionupgradeamount],[productionlevel],[coreconsumption],[effectid],[corecalories],[corekickstartthreshold],[reinforcecountermax],[bandwidthusage]
+           ,[bandwidthcapacity],[emitradius],[tint],[typeexclusiverange],[network_node_range],[hitsize],[note])
+     VALUES
+           (@definitionID,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL
+           ,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'#33000f'
+		   ,NULL,NULL,NULL,'Hersh Pitboss color');
+
+
+
+--INSERT LOOTS
+
+
+DECLARE @lootdefinitionID int;
+DECLARE @npclootID int;
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 110000, 1.0, 1,1, 75000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 25000, 1, 1,1, 20000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 25000, 1, 1,1, 20000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 25000, 1, 1,1, 20000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 125000, 1, 1,1, 100000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 50000, 1, 1,1, 50000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2500, 1, 1,1, 1000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2500, 1, 1,1, 1000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2500, 1, 1,1, 1000);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 5, 1, 1,1, 2);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 5, 1, 1,1, 2);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 6, 0.125, 1,1, 1);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 3, 0.125, 1,1, 1);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2, 0.125, 1,1, 1);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
+
+GO
+
+
+PRINT N'COMPLETE NPC_Pitboss_0_2__loot_killep_npcmods_respawnrate__2019_01_13';
+
+PRINT N'EXECUTING: NPC_Pitboss_0_3__loot_npc_fields__2019_01_27';
+
+
+USE [perpetuumsa]
+GO
+
+-------------------------
+--Pitboss updates 0_3
+--Difficulty increase; Loot-modules increase drop rates
+--2019/01/27
+-------------------------
+
+
+
+DECLARE @definitionID int;
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+
+
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=8.5 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=9.0 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=9.0 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.5 WHERE id =  @aggvalueID;
+
+
+--Loot updates to Pitboss
+
+DECLARE @lootdefinitionID int;
+DECLARE @npclootID int;
+
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=110000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=75000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=125000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=100000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=50000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=50000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=6, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=3, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
+
+GO
+
+
+PRINT N'COMPLETE NPC_Pitboss_0_3__loot_npc_fields__2019_01_27';
+
+
+PRINT N'EXECUTING: NPC_Pitboss_0_4__fitting_modifiers_loot_updates__2019_03_30';
+
+USE [perpetuumsa]
+GO
+
+-------------------------
+--Pitboss updates 0_4
+--Fitting update: add sealants
+--Modifiers update: accum multipliers 9->15x
+--2019/03/30
+-------------------------
+
+----- Change Leg modules around for reactor sealants
+
+DECLARE @templateID int;
+DECLARE @definitionID int;
+DECLARE @lootdefinitionID int;
+DECLARE @npclootID int;
+
+PRINT N'Update fitting for Pitboss';
+SET @templateID = (SELECT TOP 1 id from robottemplates WHERE [name] = 'Hersh_PitBoss' ORDER BY id DESC);
+
+UPDATE robottemplates SET name='Hersh_PitBoss', description='#robot=i1594#head=i1595#chassis=i1596#leg=i1597#container=i14c#headModules=[|m0=[|definition=i2b|slot=i1]|m1=[|definition=i32|slot=i2]|m2=[|definition=i33|slot=i3]|m3=[|definition=i34|slot=i4]]#chassisModules=[|m0=[|definition=i3d|slot=i1|ammoDefinition=i986|ammoQuantity=i32]|m1=[|definition=i3d|slot=i2|ammoDefinition=i986|ammoQuantity=i32]|m2=[|definition=i3d|slot=i3|ammoDefinition=i986|ammoQuantity=i32]|m3=[|definition=i3d|slot=i4|ammoDefinition=i988|ammoQuantity=i32]|m4=[|definition=i3d|slot=i5|ammoDefinition=i988|ammoQuantity=i32]|m5=[|definition=i3d|slot=i6|ammoDefinition=i988|ammoQuantity=i32]]#legModules=[|m0=[|definition=i10|slot=i1]|m1=[|definition=i13|slot=i2]|m2=[|definition=i13|slot=i3]|m3=[|definition=i3b7|slot=i4]|m4=[|definition=i11e0|slot=i5]|m5=[|definition=i11e0|slot=i6]]', note='Pit Boss for Hershfield' WHERE id=@templateID;
+
+
+PRINT N'Update aggregate values for Pitboss';
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+DECLARE @aggvalueID int;
+DECLARE @aggfieldID int;
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=15 WHERE id =  @aggvalueID;
+
+SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
+SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
+
+
+UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.9 WHERE id =  @aggvalueID;
+
+
+------Loot update
+
+
+PRINT N'Updating Loots for Pitboss (setting minQuantity 0->1 for some items)';
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=110000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=75000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=125000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=100000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=50000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=50000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=6, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=3, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=110000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=75000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=125000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=100000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=50000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=25000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=6, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=3, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
+SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
+UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
+
+GO
+
+PRINT N'COMPLETE NPC_Pitboss_0_4__fitting_modifiers_loot_updates__2019_03_30';
+
+
+PRINT N'Inserting EP boost T0 item into pitboss loots';
+
+USE [perpetuumsa]
+GO
+
+DECLARE @definitionID int;
+DECLARE @lootdefinitionID int;
+DECLARE @npclootID int;
+
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_boost_ep_t0' ORDER BY definition DESC);
+INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 1.0, 1, 1, 1);
+
+GO
+
+
+USE [perpetuumsa]
+GO
+
+DECLARE @definitionID int;
+SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
+
+UPDATE npcflock 
+SET npcflock.npcSpecialType=(SELECT TOP 1 value FROM dbo.npcSpecialTypes WHERE name='boss')
+WHERE definition=@definitionID;
+
+GO
+
+PRINT N'====PITBOSS PATCH COMPLETE======';
+
+
+
+
 PRINT N'Characters_welcomechar-bugfix__2019_04_25';
 ---------------------------------------------------------------------------------------------------------------------
 USE [perpetuumsa]
@@ -4697,1086 +5780,6 @@ GO
 
 
 
-
-PRINT N'PitBoss_and_EPboostitem_t0loot__2019_05_23';
-----------------------------------------------------------------------------------------------------------------
-----PART 1 ADD NEW EP ITEM
-
-
-USE [perpetuumsa]
-GO
-
--------------------------------------------------
---INSERTS ENTITYDEFAULT****
---T0 EP boost item for Pitboss loot
---REQUIRED FOR PITBOSS LOOT PATCH
---Date: 2019/05/19
--------------------------------------------------
-
-
-
-PRINT N'INSERT ENTITYDEFAULT def_boost_ep_t0';
---Insert a T0 variant EP boost item for Pitboss loot only
-INSERT INTO [dbo].[entitydefaults]
-           ([definitionname]
-           ,[quantity]
-           ,[attributeflags]
-           ,[categoryflags]
-           ,[options]
-           ,[note]
-           ,[enabled]
-           ,[volume]
-           ,[mass]
-           ,[hidden]
-           ,[health]
-           ,[descriptiontoken]
-           ,[purchasable]
-           ,[tiertype]
-           ,[tierlevel])
-     VALUES
-           ('def_boost_ep_t0'
-           ,1
-           ,2052
-           ,1179
-           ,'#addBoost=n1 #timePeriodHours=i1 #tier=$tierlevel_t0'
-           ,'Adds 1 to the current EP multiplier for 1 hours'
-           ,1
-           ,1E-06
-           ,1E-06
-           ,0
-           ,100
-           ,'def_redeemable_ep_standard_desc'
-           ,1
-           ,1
-           ,0);
-GO
-
---Insert "despawn time" as the intended duration of the item as milliseconds
-INSERT INTO dbo.aggregatevalues
-(
-	[definition],
-	[field],
-	[value]
-)
-VALUES
-(
-	(SELECT TOP 1 definition FROM entitydefaults WHERE definitionname='def_boost_ep_t0'),
-	(SELECT TOP 1 id FROM dbo.aggregatefields WHERE name='despawn_time'),
-	3600000
-);
-
-GO
-
-
----PART 2 ADD PITBOSS
-
-USE [perpetuumsa]
-GO
-
-PRINT N'PITBOSS PATCH';
---------------------------------------------------------------
---PITBOSS PATCH
---Compilation of previous dev-patches in order of execution
---NPC_Pitboss_0_0__init__2018_10_15
---NPC_Pitboss_0_1__npctweak__2018_10_27
---NPC_Pitboss_0_2__loot_killep_npcmods_respawnrate__2019_01_13
---NPC_Pitboss_0_3__loot_npc_fields__2019_01_27
---NPC_Pitboss_0_4__fitting_modifiers_loot_updates__2019_03_30
---
---REQUIRES: 00_INSERT_Entitydefault_Epboostitem_t0__2019_05_19
-------------------------------------------------------------
-
-
-
-PRINT N'EXECUTING: NPC_Pitboss_0_0__init__2018_10_15';
-
-USE [perpetuumsa]
-GO
-
---DEFINES NEW NPC
---ENTITYDEFAULT
---ROBOTTEMPLATE
---ROBOTTEMPLATERELATION
---AGGREGATEVALUES
---NPCPRESENCE
---NPCFLOCK
-
---PITBOSS ON HERSHFIELD FOR DEV-TESTING PURPOSES ONLY
-
-
-DECLARE @templateID int;
-DECLARE @definitionID int;
-DECLARE @aggvalueID int;
-DECLARE @aggfieldID int;
-DECLARE @flockID int;
-DECLARE @presenceID int;
-
-PRINT N'INSERT NEW NPC DEFINITION';
-INSERT INTO entitydefaults ( definitionname ,  quantity ,  attributeflags ,  categoryflags ,  options ,  note ,  enabled ,  volume ,  mass ,  hidden , 
-                health ,  descriptiontoken ,  purchasable ,  tiertype ,  tierlevel ) 
-                VALUES ( 'def_npc_Hersh_PitBoss', 1, 1024, 911, '', '', 1, 0, 0, 0, 100, 'def_npc_seth_heavydps_rank1_desc', 0, 0, 0); 
-
-PRINT N'INSERT NEW NPC ROBOTTEMPLATE';
-INSERT INTO robottemplates ([name], [description], [note]) VALUES ('Hersh_PitBoss', '#robot=i1594#head=i1595#chassis=i1596#leg=i1597#container=i14c#headModules=[|m0=[|definition=i2b|slot=i1]|m1=[|definition=i32|slot=i2]|m2=[|definition=i33|slot=i3]|m3=[|definition=i34|slot=i4]]#chassisModules=[|m0=[|definition=i3d|slot=i1|ammoDefinition=i986|ammoQuantity=i32]|m1=[|definition=i3d|slot=i2|ammoDefinition=i986|ammoQuantity=i32]|m2=[|definition=i3d|slot=i3|ammoDefinition=i986|ammoQuantity=i32]|m3=[|definition=i3d|slot=i4|ammoDefinition=i988|ammoQuantity=i32]|m4=[|definition=i3d|slot=i5|ammoDefinition=i988|ammoQuantity=i32]|m5=[|definition=i3d|slot=i6|ammoDefinition=i988|ammoQuantity=i32]]#legModules=[|m0=[|definition=i10|slot=i1]|m1=[|definition=i18|slot=i2]|m2=[|definition=i1a|slot=i3]|m3=[|definition=i19|slot=i4]|m4=[|definition=i1b|slot=i5]|m5=[|definition=i13|slot=i6]]', 'Pit Boss for Hershfield')
-
-
-PRINT N'INSERT NEW ROBOTTEMPLATE RELATION';
-SET @templateID = (SELECT TOP 1 id from robottemplates WHERE [name] = 'Hersh_PitBoss' ORDER BY id DESC)
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
---MISSION LEVEL AND MISSION LEVEL OVERRIDE NEED TO BE NULL!
-INSERT INTO [dbo].[robottemplaterelation] ([definition],[templateid],[itemscoresum],[raceid],[missionlevel],[missionleveloverride],[killep],[note])
-                VALUES (@definitionID,@templateID,0,0,NULL,NULL,40,'Hersh_Pit_Boss');
-
-PRINT N'INSERT AGGVALUES - NPC modifiers';
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 3.0);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.0);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.5);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'cpu_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.5);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.0);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'falloff_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.0);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_range_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.5);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.25);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'missile_cycle_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.0);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'optimal_range_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2.0);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'powergrid_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 2);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'turret_cycle_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 0.75);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'received_repaired_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 10);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_amount_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 5.0);
-
-PRINT N'INSERT NPCPRESENCE';
-INSERT INTO [dbo].[npcpresence] ([name],[topx],[topy],[bottomx],[bottomy],[note],[spawnid],[enabled],[roaming],[roamingrespawnseconds]
-                ,[presencetype],[maxrandomflock],[randomcenterx],[randomcentery],[randomradius],[dynamiclifetime],[isbodypull],[isrespawnallowed],[safebodypull])
-                VALUES ('Presence_NPC_Hersh_PitBoss',7,7,2038,2038,'Hersh_BlueBoss',13,1,1,60,5,0,0,0,0,0,0,1,1);
-
-PRINT N'INSERT NPCFLOCK';
-SET @presenceID = (SELECT TOP 1 id from npcpresence WHERE [name] = 'Presence_NPC_Hersh_PitBoss' ORDER BY id DESC)
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-SET @flockID = (SELECT TOP 1 id from npcflock WHERE [name] = 'Hersh_Pit_Boss' ORDER BY id DESC);
-INSERT INTO[dbo].[npcflock]([name],[presenceid],[flockmembercount],[definition],[spawnoriginX],[spawnoriginY],[spawnrangeMin],[spawnrangeMax],[respawnseconds]
-                ,[totalspawncount],[homerange],[note],[respawnmultiplierlow],[enabled],[iscallforhelp],[behaviorType]) VALUES
-                ('Hersh_Pit_Boss', @presenceID, 1, @definitionID, 933, 1231, 0, 5, 60, 0, 100, 'Hersh_Pit_Boss', 1, 1, 1, 1); 
-
-GO
-
-PRINT N'COMPLETE: NPC_Pitboss_0_0__init__2018_10_15';
-
-PRINT N'EXECUTING: NPC_Pitboss_0_1__npctweak__2018_10_27';
-
-USE [perpetuumsa]
-GO
-
---PITBOSS experiment balance part 2
---Insert slowdown and masking drop
---update other npc properties
-
-DECLARE @definitionID int;
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-UPDATE entitydefaults Set definitionname='def_npc_Hersh_PitBoss', quantity=1, attributeflags=1024, categoryflags=911, options='', 
-                note='', enabled=1, volume=0, mass=0, hidden='False', health=100, descriptiontoken='def_npc_seth_heavydps_rank1_desc', purchasable=0, tiertype=0, 
-                tierlevel=0 where definition=@definitionID;
-
-DECLARE @aggvalueID int;
-DECLARE @aggfieldID int;
-
---Set Speed of Pitboss to 50% of its max
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'speed_max_modifier' ORDER BY [name] DESC);
-
-INSERT INTO [dbo].[aggregatevalues]
-           ([definition],[field],[value])
-     VALUES
-           (@definitionID, @aggfieldID, 0.5);
-
-
---Set modification of masking to -70 (result effect will be masking =10)
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'stealth_strength_modifier' ORDER BY [name] DESC);
-
-INSERT INTO [dbo].[aggregatevalues]
-           ([definition],[field],[value])
-     VALUES
-           (@definitionID, @aggfieldID, -70);
-
-
-
---Redundant updates to above inserts -- For use as template to future tweaks
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'stealth_strength_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=-50 WHERE id =  @aggvalueID;
-
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'speed_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.5 WHERE id =  @aggvalueID;
-
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=3.1 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_amount_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=10.1 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.1 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.1 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'cpu_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=2.6 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.1 WHERE id =  @aggvalueID;
-
-
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'falloff_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.6 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_range_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.6 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'locking_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.6 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'missile_cycle_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.85 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'optimal_range_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.1 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'powergrid_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=2.1 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'turret_cycle_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.85 WHERE id =  @aggvalueID;
-
---Redundant updates to above inserts --
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'stealth_strength_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=-50 WHERE id =  @aggvalueID;
-
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'speed_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.5 WHERE id =  @aggvalueID;
-
-GO
-
-PRINT N'COMPLETE NPC_Pitboss_0_1__npctweak__2018_10_27';
-
-
-PRINT N'EXECUTING: NPC_Pitboss_0_2__loot_killep_npcmods_respawnrate__2019_01_13';
-
-
-USE [perpetuumsa]
-GO
-
-
---SETS RESPAWN RATE TO 5 DAYS
---UPDATES TEMPLATE/FITTINGS
---KILLEP SET TO 1000
---FASTER ARMOR REPAIR
---FULL LOOT TABLE
---Add Color!
-
---PITBOSS ON HERSHFIELD FOR DEV-TESTING PURPOSES ONLY
-
-DECLARE @presenceID int
-DECLARE @flockID int;
-DECLARE @definitionID int;
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-
---Presence Update - set respawn timer to 5 days!
-SET @presenceID = (SELECT TOP 1 id from npcpresence WHERE [name] = 'Presence_NPC_Hersh_PitBoss' ORDER BY id DESC)
-UPDATE [dbo].[npcpresence] SET [name] = 'Presence_NPC_Hersh_PitBoss',
-[topx] = 7,[topy] = 7,[bottomx] = 2038,[bottomy] = 2038,[note] = 'Hersh_Boss',[spawnid] = 13,[enabled] = 1,[roaming] = 1,
-[roamingrespawnseconds] = 432000, [presencetype] = 5, [maxrandomflock] = '', [randomcenterx] = '', [randomcentery] = '', 
-[randomradius] = '',[dynamiclifetime] = '' ,[isbodypull] = 0,[isrespawnallowed] = 1,[safebodypull] = 1
-WHERE id=@presenceID;
-
---Set Flock respawn too (to be consistent)
-SET @flockID = (SELECT TOP 1 id from npcflock WHERE [name] = 'Hersh_Pit_Boss' ORDER BY id DESC);
-UPDATE [dbo].[npcflock] SET 
-[name] = 'Hersh_Pit_Boss' ,[presenceid] = @presenceID, [flockmembercount] = 1, 
-[definition] = @definitionID, [spawnoriginX] = 933, [spawnoriginY] = 1231 ,
-[spawnrangeMin] = 0, [spawnrangeMax] = 5,[respawnseconds] = 432000, 
-[totalspawncount] = 0, [homerange] = 100 ,[note] = 'Hersh_Pit_Boss',
-[respawnmultiplierlow] = 1, [enabled] = 1, [iscallforhelp] = 1, [behaviorType] = 1 
-WHERE id=@flockID;
-
-
-
-DECLARE @templateID int;
-SET @templateID = (SELECT TOP 1 id from robottemplates WHERE [name] = 'Hersh_PitBoss' ORDER BY id DESC);
-
---Update fittings
-UPDATE robottemplates SET 
-name='Hersh_PitBoss', 
-description='#robot=i1594#head=i1595#chassis=i1596#leg=i1597#container=i14c#headModules=[|m0=[|definition=i2b|slot=i1]|m1=[|definition=i32|slot=i2]|m2=[|definition=i33|slot=i3]|m3=[|definition=i34|slot=i4]]#chassisModules=[|m0=[|definition=i3d|slot=i1|ammoDefinition=i986|ammoQuantity=i32]|m1=[|definition=i3d|slot=i2|ammoDefinition=i986|ammoQuantity=i32]|m2=[|definition=i3d|slot=i3|ammoDefinition=i986|ammoQuantity=i32]|m3=[|definition=i3d|slot=i4|ammoDefinition=i988|ammoQuantity=i32]|m4=[|definition=i3d|slot=i5|ammoDefinition=i988|ammoQuantity=i32]|m5=[|definition=i3d|slot=i6|ammoDefinition=i988|ammoQuantity=i32]]#legModules=[|m0=[|definition=i10|slot=i1]|m1=[|definition=i18|slot=i2]|m2=[|definition=i1a|slot=i3]|m3=[|definition=i1b|slot=i4]|m4=[|definition=i13|slot=i5]|m5=[|definition=i13|slot=i6]]',
-note='Pit Boss for Hershfield' 
-WHERE id=@templateID;
-
---Update KillEP = 1000!
-UPDATE [dbo].[robottemplaterelation] SET 
-[templateid] = @templateID,[itemscoresum] = 0,[raceid] = 0,
-[missionlevel] = NULL,[missionleveloverride] = NULL,[killep] = 1000,
-[note] = 'Hersh_Pit_Boss' 
-WHERE [definition] = @definitionID;
-
-
---Add faster armor repair cycles, resistance, accum
-DECLARE @aggvalueID int;
-DECLARE @aggfieldID int;
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_cycle_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 1.75);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_chemical' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_explosive' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_kinetic' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'resist_thermal' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-INSERT INTO [dbo].[aggregatevalues] ([definition],[field],[value]) VALUES (@definitionID, @aggfieldID, 300);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=3.5 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_repair_amount_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=12.5 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.15 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.5 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=4.5 WHERE id =  @aggvalueID;
-
-
----Add Color
-
-INSERT INTO [dbo].[definitionconfig]
-           ([definition],[targetdefinition],[summonerscount],[npcpresenceid],[item_work_range],[explosion_radius],[cycle_time],[damage_chemical]
-           ,[damage_explosive],[damage_kinetic],[damage_thermal],[lifetime],[activationtime],[waves],[missionrelated],[constructionradius],[action_delay]
-           ,[deploy_radius],[transmitradius],[constructionlevelmax],[blockingradius],[chargeamount],[inconnections],[outconnections],[coretransferred],[transferefficiency]
-           ,[productionupgradeamount],[productionlevel],[coreconsumption],[effectid],[corecalories],[corekickstartthreshold],[reinforcecountermax],[bandwidthusage]
-           ,[bandwidthcapacity],[emitradius],[tint],[typeexclusiverange],[network_node_range],[hitsize],[note])
-     VALUES
-           (@definitionID,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL
-           ,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'#33000f'
-		   ,NULL,NULL,NULL,'Hersh Pitboss color');
-
-
-
---INSERT LOOTS
-
-
-DECLARE @lootdefinitionID int;
-DECLARE @npclootID int;
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 110000, 1.0, 1,1, 75000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 25000, 1, 1,1, 20000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 25000, 1, 1,1, 20000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 25000, 1, 1,1, 20000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 125000, 1, 1,1, 100000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 50000, 1, 1,1, 50000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2500, 1, 1,1, 1000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2500, 1, 1,1, 1000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2500, 1, 1,1, 1000);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 5, 1, 1,1, 2);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 5, 1, 1,1, 2);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 6, 0.125, 1,1, 1);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 3, 0.125, 1,1, 1);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 2, 0.125, 1,1, 1);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 0.125, 1,1, 0);
-
-GO
-
-
-PRINT N'COMPLETE NPC_Pitboss_0_2__loot_killep_npcmods_respawnrate__2019_01_13';
-
-PRINT N'EXECUTING: NPC_Pitboss_0_3__loot_npc_fields__2019_01_27';
-
-
-USE [perpetuumsa]
-GO
-
--------------------------
---Pitboss updates 0_3
---Difficulty increase; Loot-modules increase drop rates
---2019/01/27
--------------------------
-
-
-
-DECLARE @definitionID int;
-DECLARE @aggvalueID int;
-DECLARE @aggfieldID int;
-
-
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'armor_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=8.5 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=9.0 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=9.0 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'damage_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=1.5 WHERE id =  @aggvalueID;
-
-
---Loot updates to Pitboss
-
-DECLARE @lootdefinitionID int;
-DECLARE @npclootID int;
-
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=110000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=75000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=125000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=100000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=50000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=50000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=6, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=3, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=0 WHERE [id]=@npclootID;
-
-GO
-
-
-PRINT N'COMPLETE NPC_Pitboss_0_3__loot_npc_fields__2019_01_27';
-
-
-PRINT N'EXECUTING: NPC_Pitboss_0_4__fitting_modifiers_loot_updates__2019_03_30';
-
-USE [perpetuumsa]
-GO
-
--------------------------
---Pitboss updates 0_4
---Fitting update: add sealants
---Modifiers update: accum multipliers 9->15x
---2019/03/30
--------------------------
-
------ Change Leg modules around for reactor sealants
-
-DECLARE @templateID int;
-DECLARE @definitionID int;
-DECLARE @lootdefinitionID int;
-DECLARE @npclootID int;
-
-PRINT N'Update fitting for Pitboss';
-SET @templateID = (SELECT TOP 1 id from robottemplates WHERE [name] = 'Hersh_PitBoss' ORDER BY id DESC);
-
-UPDATE robottemplates SET name='Hersh_PitBoss', description='#robot=i1594#head=i1595#chassis=i1596#leg=i1597#container=i14c#headModules=[|m0=[|definition=i2b|slot=i1]|m1=[|definition=i32|slot=i2]|m2=[|definition=i33|slot=i3]|m3=[|definition=i34|slot=i4]]#chassisModules=[|m0=[|definition=i3d|slot=i1|ammoDefinition=i986|ammoQuantity=i32]|m1=[|definition=i3d|slot=i2|ammoDefinition=i986|ammoQuantity=i32]|m2=[|definition=i3d|slot=i3|ammoDefinition=i986|ammoQuantity=i32]|m3=[|definition=i3d|slot=i4|ammoDefinition=i988|ammoQuantity=i32]|m4=[|definition=i3d|slot=i5|ammoDefinition=i988|ammoQuantity=i32]|m5=[|definition=i3d|slot=i6|ammoDefinition=i988|ammoQuantity=i32]]#legModules=[|m0=[|definition=i10|slot=i1]|m1=[|definition=i13|slot=i2]|m2=[|definition=i13|slot=i3]|m3=[|definition=i3b7|slot=i4]|m4=[|definition=i11e0|slot=i5]|m5=[|definition=i11e0|slot=i6]]', note='Pit Boss for Hershfield' WHERE id=@templateID;
-
-
-PRINT N'Update aggregate values for Pitboss';
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-DECLARE @aggvalueID int;
-DECLARE @aggfieldID int;
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_max_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=15 WHERE id =  @aggvalueID;
-
-SET @aggfieldID = (SELECT TOP 1 id from aggregatefields WHERE [name] = 'core_recharge_time_modifier' ORDER BY [name] DESC);
-SET @aggvalueID = (SELECT TOP 1 id from aggregatevalues WHERE [definition] = @definitionID AND [field]=@aggfieldID ORDER BY definition DESC);
-
-
-UPDATE aggregatevalues SET definition=@definitionID, field=@aggfieldID, value=0.9 WHERE id =  @aggvalueID;
-
-
-------Loot update
-
-
-PRINT N'Updating Loots for Pitboss (setting minQuantity 0->1 for some items)';
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=110000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=75000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=125000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=100000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=50000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=50000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=6, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=3, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.5, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_common_reactor_plasma' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=110000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=75000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_pelistal' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_thelodica' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_nuimqol' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=25000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=20000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_common' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=125000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=100000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_kernel_hitech' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=50000, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=25000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_basic' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_advanced' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_robotshard_common_expert' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2500, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=1000 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_9' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_research_kit_10' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=5, [probability]=1, [repackaged]=1, [dontdamage]=1, [minquantity]=2 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_plate' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_armor_repairer' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_thrm_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_chm_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_kin_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_exp_armor_hardener' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_booster' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_sensor_jammer' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_medium_autocannon' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=6, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_damage_mod_projectile' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=3, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_armor_repairer_upgrade' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=2, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_speed_module' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_precision_firing_module' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_gang_assist_ewar_range_module_pr' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_stealth_modul' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_small_shield_generator' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_artifact_a_medium_shield_generator' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_reactor_sealing' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_named2_energy_warfare_upgrade' ORDER BY definition DESC);
-SET @npclootID = (SELECT TOP 1 id from npcloot WHERE definition = @definitionID AND lootdefinition = @lootdefinitionID  ORDER BY definition, lootdefinition DESC);
-UPDATE npcloot SET [definition]=@definitionID, [lootdefinition]=@lootdefinitionID, [quantity]=1, [probability]=0.125, [repackaged]=1, [dontdamage]=1, [minquantity]=1 WHERE [id]=@npclootID;
-
-GO
-
-PRINT N'COMPLETE NPC_Pitboss_0_4__fitting_modifiers_loot_updates__2019_03_30';
-
-
-PRINT N'Inserting EP boost T0 item into pitboss loots';
-
-USE [perpetuumsa]
-GO
-
-DECLARE @definitionID int;
-DECLARE @lootdefinitionID int;
-DECLARE @npclootID int;
-
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-SET @lootdefinitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_boost_ep_t0' ORDER BY definition DESC);
-INSERT INTO [dbo].[npcloot] ([definition],[lootdefinition],[quantity],[probability],[repackaged],[dontdamage],[minquantity]) VALUES(@definitionID, @lootdefinitionID, 1, 1.0, 1, 1, 1);
-
-GO
-
-
-USE [perpetuumsa]
-GO
-
-DECLARE @definitionID int;
-SET @definitionID = (SELECT TOP 1 definition from entitydefaults WHERE [definitionname] = 'def_npc_Hersh_PitBoss' ORDER BY definition DESC);
-
-UPDATE npcflock 
-SET npcflock.npcSpecialType=(SELECT TOP 1 value FROM dbo.npcSpecialTypes WHERE name='boss')
-WHERE definition=@definitionID;
-
-GO
-
-PRINT N'====PITBOSS PATCH COMPLETE======';
 
 ---------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/Patches/Pre_Alpha_0/prealpha_patch_0.sql
+++ b/Patches/Pre_Alpha_0/prealpha_patch_0.sql
@@ -1,0 +1,28 @@
+USE [perpetuumsa]
+GO
+
+
+DECLARE @newsCat AS INT = (SELECT TOP 1 id FROM newscategories WHERE category='newscat_developer');
+
+UPDATE channels SET 
+	topic = 'You are running the Open Perpetuum Server! https://OpenPerpetuum.com for more details';
+
+INSERT INTO news (title,body,type,language) VALUES
+('OPP Server Info',
+N'Thank you for choosing the Open Perpetuum Server for your Perpetuum Server needs!
+Please note that OPP does NOT provide technical support.  Your server; your responsibility!
+If you require assistance, please content AC at: info@perpetuum-online.com
+
+For more details on Open Perpetuum - the free, volunteer run, open source, Perpetuum server check the website: https://OpenPerpetuum.com
+Want to join the team? https://openperpetuum.com/volunteer
+Or contribute your own fixes or features to our github: https://github.com/OpenPerpetuum
+Or support free, open source development and the live server by donating at: https://patreon.com/OpenPerpetuum
+',
+@newsCat,0);
+
+UPDATE serverinfo SET
+	name='Dev instance of OPP server',
+	description='This server is running Open Perpetuum - a fork of the Perpetuum Online server',
+	isbroadcast=0,
+	isopen=0;
+GO

--- a/apply_all.bat
+++ b/apply_all.bat
@@ -21,6 +21,7 @@ echo Restoring original database state
 %StartAndWait% %SqlCmd% "%TOOLS_DIR%\restore_DB_to_original_state.sql"
 
 :: Apply the patches in order
+call:applyPatch Pre_Alpha_0 prealpha_patch_0.sql
 call:applyPatch Pre_Alpha_1 prealpha_patch_1.sql Server
 call:applyPatch Pre_Alpha_2 prealpha_patch_2.sql Server
 call:applyPatch Pre_Alpha_3 prealpha_patch_3.sql


### PR DESCRIPTION
Fixes to patches applied in the past that were bundled after-the-fact, causing for some out of order insertions to be out of step with numerical ID's that must match res server ids.

Basically just to clean up some weird display issues on dev servers.